### PR TITLE
fix: replaced GITHUB_TOKEN by PAT to make release workflow callable b…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
 
       - name: Initialize Submodules
         run: source ${{ env.SCRIPTS_DIR }}/initialize_submodules.sh
@@ -60,7 +62,7 @@ jobs:
       - name: Create Release
         uses: marvinpinto/action-automatic-releases@latest
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.PAT }}
           automatic_release_tag: "latest"
           prerelase: true
           title: "Pre-release"


### PR DESCRIPTION
Switched to Personal Access Token instead of GITHUB_TOKEN, to make the release workflow callable by bump. 